### PR TITLE
M1 thread support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ output/
 ZeOSSysenter.tar.gz
 !lab_exams/L1/ZeOSSysenter.tar.gz
 output
+.cache
+*.json

--- a/project/Makefile
+++ b/project/Makefile
@@ -150,13 +150,13 @@ backup: clean
 	@mkdir -p ../backup/zeos_versions
 	@mkdir -p ../backup/project_versions
 	@TIMESTAMP=$$(date +%Y%m%d_%H%M%S) && \
-	BACKUP_NAME="zeos_v$$TIMESTAMP.tar.gz" && \
-	if [ -f ../backup/zeos_versions/$$BACKUP_NAME ]; then \
+	BACKUP_NAME="project_v$$TIMESTAMP.tar.gz" && \
+	if [ -f ../backup/project_versions/$$BACKUP_NAME ]; then \
 		echo "Error: File $$BACKUP_NAME already exists!"; \
 		exit 1; \
 	fi && \
-	echo "Creating ZeOS backup: $$BACKUP_NAME" && \
-	cd .. && tar -czvf backup/zeos_versions/$$BACKUP_NAME zeos/
+	echo "Creating Project backup: $$BACKUP_NAME" && \
+	cd .. && tar -czvf backup/project_versions/$$BACKUP_NAME project/
 
 # Write the ZeOS binary image to floppy disk device (legacy target, requires floppy drive)
 disk: zeos.bin
@@ -221,16 +221,16 @@ format:
 doxygen:
 	@if command -v doxygen >/dev/null 2>&1; then \
         echo "Generating Doxygen documentation..."; \
-        cd ../docs/doxygen/zeos && doxygen Doxyfile; \
-        echo "Documentation generated in docs/doxygen/zeos/output/html/"; \
+        cd ../docs/doxygen/project && doxygen Doxyfile; \
+        echo "Documentation generated in docs/doxygen/project/output/html/"; \
 	else \
         echo "Error: Doxygen is not installed. Please install it with 'sudo apt install doxygen' (Ubuntu/Debian) or equivalent for your system."; \
     fi
 
 doxygen-pdf:
-	@if [ -d "../docs/doxygen/zeos/output/latex" ]; then \
-        cd ../docs/doxygen/zeos/output/latex && make; \
-        echo "PDF generated: ../docs/doxygen/zeos/output/latex/refman.pdf"; \
+	@if [ -d "../docs/doxygen/project/output/latex" ]; then \
+        cd ../docs/doxygen/project/output/latex && make; \
+        echo "PDF generated: ../docs/doxygen/project/output/latex/refman.pdf"; \
 	else \
         echo "Run 'make doxygen' first to generate LaTeX files."; \
     fi

--- a/project/include/debug.h
+++ b/project/include/debug.h
@@ -11,13 +11,13 @@
 #define __DEBUG_H__
 
 // clang-format off
-#define DEBUG_INFO_TASK_SWITCH          1
-#define DEBUG_INFO_FORK                 1
-#define DEBUG_INFO_EXIT                 1
+#define DEBUG_INFO_TASK_SWITCH          0
+#define DEBUG_INFO_FORK                 0
+#define DEBUG_INFO_EXIT                 0
 #define DEBUG_INFO_BLOCK                0
 #define DEBUG_INFO_UNBLOCK              0
-#define DEBUG_INFO_THREAD_CREATE        1
-#define DEBUG_INFO_THREAD_EXIT          1
+#define DEBUG_INFO_THREAD_CREATE        0
+#define DEBUG_INFO_THREAD_EXIT          0
 // clang-format on
 
 #endif /* __DEBUG_H__ */

--- a/project/include/sys.h
+++ b/project/include/sys.h
@@ -151,10 +151,15 @@ int sys_getpid(void);
  */
 int check_fd(int fd, int permissions);
 
+/* Thread stack configuration */
 #define THREAD_STACK_REGION_PAGES 8
 #define THREAD_STACK_INITIAL_PAGES 1
 #define THREAD_STACK_BASE_PAGE (PAG_LOG_INIT_CODE + NUM_PAG_CODE)
-#define TEMP_STACK_MAPPING_PAGE (NUM_PAG_KERNEL + NUM_PAG_CODE + NUM_PAG_DATA)
+
+/* Temporary mapping pages - use end of address space to avoid conflicts with thread stacks */
+/* TOTAL_PAGES = 1024, so we use pages near the end for temporary mappings */
+#define TEMP_STACK_MAPPING_PAGE (TOTAL_PAGES - THREAD_STACK_INITIAL_PAGES - 1)  /* Page 1022 */
+#define FORK_TEMP_MAPPING_PAGE (TOTAL_PAGES - NUM_PAG_DATA - 2)                  /* Page 1002 */
 
 /**
  * @brief Create a new thread in the current process.

--- a/project/include/sys.h
+++ b/project/include/sys.h
@@ -158,8 +158,8 @@ int check_fd(int fd, int permissions);
 
 /* Temporary mapping pages - use end of address space to avoid conflicts with thread stacks */
 /* TOTAL_PAGES = 1024, so we use pages near the end for temporary mappings */
-#define TEMP_STACK_MAPPING_PAGE (TOTAL_PAGES - THREAD_STACK_INITIAL_PAGES - 1)  /* Page 1022 */
-#define FORK_TEMP_MAPPING_PAGE (TOTAL_PAGES - NUM_PAG_DATA - 2)                  /* Page 1002 */
+#define TEMP_STACK_MAPPING_PAGE (TOTAL_PAGES - THREAD_STACK_INITIAL_PAGES - 1) /* Page 1022 */
+#define FORK_TEMP_MAPPING_PAGE (TOTAL_PAGES - NUM_PAG_DATA - 2)                /* Page 1002 */
 
 /**
  * @brief Create a new thread in the current process.

--- a/project/project_test.c
+++ b/project/project_test.c
@@ -1,9 +1,15 @@
 /**
  * @file project_test.c
  * @brief Test suite for thread support in ZeOS.
+ *
+ * This file implements comprehensive tests for thread functionality including:
+ * - Thread creation up to maximum limit
+ * - TID reuse after thread deletion
+ * - Process termination when last thread exits
+ * - Master thread reassignment
+ * - Fork copying only current thread
  */
 
-#include <errno.h>
 #include <libc.h>
 #include <project_test.h>
 #include <zeos_test.h>
@@ -12,279 +18,68 @@ extern char buffer[BUFFER_SIZE];
 extern char *msg;
 extern int errno;
 
-/* Global variables for thread coordination */
-static volatile int thread_finished = 0;
-static int subtests_run = 0;
-static int subtests_passed = 0;
+/* Synchronization flags - volatile for thread visibility */
+static volatile int sync_flags[MAX_SYNC_FLAGS];
 
-/* ---- Basic Thread Tests (always run, no defines) ---- */
+/* Test counters */
+static int thread_subtests_run = 0;
+static int thread_subtests_passed = 0;
 
-static void test_thread_create_basic(void) {
-    msg = "[TEST 1] Basic thread creation...\n";
-    write(1, msg, strlen(msg));
+/* ============================================================
+ *                    SYNCHRONIZATION UTILITIES
+ * ============================================================ */
 
-    thread_finished = 0;
-    int work_time = SHORT_WORK_TIME;
-    int tid = ThreadCreate(thread_work, &work_time);
-
-    if (tid > 0) {
-        msg = " - PASSED (created TID ";
-        write(1, msg, strlen(msg));
-        itoa(tid, buffer);
-        write(1, buffer, strlen(buffer));
-        msg = ")\n";
-        write(1, msg, strlen(msg));
-    } else {
-        msg = " - FAILED\n";
-        write(1, msg, strlen(msg));
+void clear_all_flags(void) {
+    for (int i = 0; i < MAX_SYNC_FLAGS; i++) {
+        sync_flags[i] = 0;
     }
 }
 
-static void test_thread_exit_basic(void) {
-    msg = "[TEST 2] Thread exit verification...\n";
-    write(1, msg, strlen(msg));
-
-    int wait_start = gettime();
-    int timeout = MEDIUM_WORK_TIME;
-
-    while (!thread_finished && (gettime() - wait_start < timeout)) {
-        /* Busy wait */
-    }
-
-    if (thread_finished) {
-        msg = " - PASSED (thread exited successfully)\n";
-        write(1, msg, strlen(msg));
-    } else {
-        msg = " - FAILED (timeout)\n";
-        write(1, msg, strlen(msg));
+void set_flag(int flag_index) {
+    if (flag_index >= 0 && flag_index < MAX_SYNC_FLAGS) {
+        sync_flags[flag_index] = 1;
     }
 }
 
-/* ---- Advanced Thread Tests ---- */
+int is_flag_set(int flag_index) {
+    if (flag_index >= 0 && flag_index < MAX_SYNC_FLAGS) {
+        return sync_flags[flag_index];
+    }
+    return 0;
+}
 
-void test_thread_advanced(void) {
-    print_test_header("ADVANCED THREAD TESTS");
-
-    int pid = fork();
-
-    if (pid == 0) {
-        /* Child process (PID 2) - runs all subtests */
-        subtests_run = 0;
-        subtests_passed = 0;
-
-        /* Subtest 1: Create max threads (5) */
-        msg = "[TEST 1] Create maximum threads...\n";
-        write(1, msg, strlen(msg));
-
-        int tids[MAX_THREADS_PER_PROCESS];
-        int created = 0;
-        int min_time = MIN_WORK_TIME;
-
-        for (int i = 0; i < MAX_THREADS_PER_PROCESS; i++) {
-            tids[i] = ThreadCreate(thread_work, &min_time);
-            if (tids[i] > 0) created++;
-        }
-
-        if (created == MAX_THREADS_PER_PROCESS) {
-            msg = " - PASSED (created 5 threads)\n";
-            write(1, msg, strlen(msg));
-            subtests_passed++;
-        } else {
-            msg = " - FAILED\n";
-            write(1, msg, strlen(msg));
-        }
-        subtests_run++;
-
-        /* Subtest 2: Verify creation fails when limit reached */
-        msg = "[TEST 2] Verify max thread limit...\n";
-        write(1, msg, strlen(msg));
-
-        int tid_extra = ThreadCreate(thread_work, &min_time);
-        if (tid_extra == -1) {
-            msg = " - PASSED (correctly rejected 6th thread)\n";
-            write(1, msg, strlen(msg));
-            subtests_passed++;
-        } else {
-            msg = " - FAILED\n";
-            write(1, msg, strlen(msg));
-        }
-        subtests_run++;
-
-        /* Subtest 3: TID reuse after thread deletion */
-        msg = "[TEST 3] TID reuse after deletion...\n";
-        write(1, msg, strlen(msg));
-
-        wait_for_ticks(SHORT_WORK_TIME); // Wait for threads to exit
-
-        int tid_reused = ThreadCreate(thread_work, &min_time);
-        if (tid_reused > 0) {
-            msg = " - PASSED (TID ";
-            write(1, msg, strlen(msg));
-            itoa(tid_reused, buffer);
-            write(1, buffer, strlen(buffer));
-            msg = " reused)\n";
-            write(1, msg, strlen(msg));
-            subtests_passed++;
-        } else {
-            msg = " - FAILED\n";
-            write(1, msg, strlen(msg));
-        }
-        subtests_run++;
-
-        /* Subtest 4: Master reassignment when current master exits */
-        msg = "[TEST 4] Master thread reassignment...\n";
-        write(1, msg, strlen(msg));
-
-        int work_time = MEDIUM_WORK_TIME;
-        int tid_new = ThreadCreate(thread_work, &work_time);
-
-        if (tid_new > 0) {
-            msg = " - Master will exit, new master TID ";
-            write(1, msg, strlen(msg));
-            itoa(tid_new, buffer);
-            write(1, buffer, strlen(buffer));
-            msg = "\n";
-            write(1, msg, strlen(msg));
-
-            ThreadExit(); // Master exits
-        }
-
-        /* Should not reach here */
-        exit();
-
-    } else if (pid > 0) {
-        /* Parent - wait for child */
-        wait_for_ticks(LONG_WORK_TIME + 2000);
-
-        msg = "\n[THREAD_ADVANCED] Subtests: ";
-        write(1, msg, strlen(msg));
-        msg = "4/4 passed\n\n";
-        write(1, msg, strlen(msg));
-
-        print_test_result("Advanced Thread Tests", 1);
-    } else {
-        print_test_result("Advanced Thread Tests", 0);
+void wait_for_flag(int flag_index) {
+    while (!is_flag_set(flag_index)) {
+        /* Deterministic spin-wait until flag is set */
     }
 }
 
-void test_thread_fork(void) {
-    print_test_header("FORK WITH THREADS");
-
-    subtests_run = 0;
-    subtests_passed = 0;
-
-    msg = "[TEST 1] Fork copies only current thread...\n";
-    write(1, msg, strlen(msg));
-
-    int min_time = MIN_WORK_TIME;
-    int tid1 = ThreadCreate(thread_work, &min_time);
-
-    if (tid1 > 0) {
-        int pid = fork();
-
-        if (pid == 0) {
-            /* Child */
-            int tid_child = ThreadCreate(thread_work, &min_time);
-            if (tid_child > 0) {
-                msg = " - PASSED (child created TID ";
-                write(1, msg, strlen(msg));
-                itoa(tid_child, buffer);
-                write(1, buffer, strlen(buffer));
-                msg = ")\n";
-                write(1, msg, strlen(msg));
-            }
-            wait_for_ticks(SHORT_WORK_TIME);
-            exit();
-
-        } else if (pid > 0) {
-            wait_for_ticks(MEDIUM_WORK_TIME);
-            subtests_passed++;
-        }
-        subtests_run++;
+/* Wait for multiple flags to be set */
+static void wait_for_flags(int count) {
+    for (int i = 0; i < count; i++) {
+        wait_for_flag(i);
     }
-
-    msg = "\n[FORK_THREADS] Subtests: ";
-    write(1, msg, strlen(msg));
-    itoa(subtests_passed, buffer);
-    write(1, buffer, strlen(buffer));
-    msg = "/";
-    write(1, msg, strlen(msg));
-    itoa(subtests_run, buffer);
-    write(1, buffer, strlen(buffer));
-    msg = " passed\n\n";
-    write(1, msg, strlen(msg));
-
-    print_test_result("Fork with Threads", subtests_passed == subtests_run);
 }
 
-/* ---- Main Test Execution ---- */
+/* ============================================================
+ *                    THREAD WORK FUNCTIONS
+ * ============================================================ */
 
-void execute_project_tests(void) {
-    msg = "\n=========================================\n";
-    write(1, msg, strlen(msg));
-    msg = "      THREAD TEST SUITE                  \n";
-    write(1, msg, strlen(msg));
-    msg = "=========================================\n\n";
-    write(1, msg, strlen(msg));
-
-#if THREAD_ADVANCED_TEST
-    RESET_ERRNO();
-    test_thread_advanced();
-#endif
-
-#if THREAD_FORK_TEST
-    RESET_ERRNO();
-    test_thread_fork();
-#endif
-
-    msg = "\n=========================================\n";
-    write(1, msg, strlen(msg));
-    msg = "      ALL TESTS COMPLETED                \n";
-    write(1, msg, strlen(msg));
-    msg = "=========================================\n\n";
-    write(1, msg, strlen(msg));
-
-#if IDLE_SWITCH_TEST
-    write_current_info();
-    msg = "Terminating init process. System will switch to idle.\n";
-    write(1, msg, strlen(msg));
-    exit();
-#endif
-}
-
-/* ---- Basic Thread Tests ---- */
-
-void execute_basic_thread_tests(void) {
-    print_test_header("BASIC THREAD TESTS");
-    test_thread_create_basic();
-    test_thread_exit_basic();
-    print_test_result("Basic Thread Tests", 1);
-}
-
-/* ---- Helper Functions ---- */
-
-void wait_for_ticks(int ticks) {
-    int start_time = gettime();
+void simple_thread_func(void *arg) {
+    int flag_index = *(int *)arg;
 
     write_current_info();
-    msg = "Waiting for ";
+    msg = "Simple thread running, will set flag ";
     write(1, msg, strlen(msg));
-    itoa(ticks, buffer);
+    itoa(flag_index, buffer);
     write(1, buffer, strlen(buffer));
-    msg = " ticks...\n";
+    msg = "\n";
     write(1, msg, strlen(msg));
 
-    while (gettime() - start_time < ticks) {
-        /* Busy wait */
-    }
+    /* Signal completion */
+    set_flag(flag_index);
 
-    write_current_info();
-    msg = "End waiting time of ";
-    write(1, msg, strlen(msg));
-    itoa(ticks, buffer);
-    write(1, buffer, strlen(buffer));
-    msg = " ticks\n";
-    write(1, msg, strlen(msg));
+    ThreadExit();
 }
 
 void thread_work(void *arg) {
@@ -304,11 +99,69 @@ void thread_work(void *arg) {
     }
 
     write_current_info();
-    msg = "Thread finished\n";
+    msg = "Thread finished work\n";
     write(1, msg, strlen(msg));
 
-    thread_finished = 1;
     ThreadExit();
+}
+
+void thread_block_func(void *arg) {
+    int flag_index = *(int *)arg;
+
+    write_current_info();
+    msg = "Thread will set flag and block\n";
+    write(1, msg, strlen(msg));
+
+    set_flag(flag_index);
+    block();
+
+    /* After being unblocked */
+    write_current_info();
+    msg = "Thread was unblocked\n";
+    write(1, msg, strlen(msg));
+
+    ThreadExit();
+}
+
+/* Thread that just exits immediately - for testing thread limits */
+static void minimal_thread_func(void *arg) {
+    int flag_index = *(int *)arg;
+    set_flag(flag_index);
+    ThreadExit();
+}
+
+/* Thread for master reassignment test - stays alive */
+static void survivor_thread_func(void *arg) {
+    int flag_index = *(int *)arg;
+
+    write_current_info();
+    msg = "Survivor thread started, waiting for master to exit\n";
+    write(1, msg, strlen(msg));
+
+    /* Signal that we're ready */
+    set_flag(flag_index);
+
+    /* Work for a while - we should become master */
+    int start = gettime();
+    while (gettime() - start < MEDIUM_WORK_TIME) { }
+
+    write_current_info();
+    msg = "Survivor thread: I am now master (hopefully), exiting process\n";
+    write(1, msg, strlen(msg));
+
+    /* Exit the process */
+    exit();
+}
+
+/* ============================================================
+ *                    UTILITY FUNCTIONS
+ * ============================================================ */
+
+void waitTicks(int ticks) {
+    int start_time = gettime();
+    while (gettime() - start_time < ticks) {
+        /* Busy wait */
+    }
 }
 
 void write_current_info(void) {
@@ -322,4 +175,545 @@ void write_current_info(void) {
     write(1, buffer, strlen(buffer));
     msg = "] ";
     write(1, msg, strlen(msg));
+}
+
+static void print_subtest_header(int num, char *name) {
+    msg = "\n[SUBTEST ";
+    write(1, msg, strlen(msg));
+    itoa(num, buffer);
+    write(1, buffer, strlen(buffer));
+    msg = "] ";
+    write(1, msg, strlen(msg));
+    write(1, name, strlen(name));
+    msg = "\n";
+    write(1, msg, strlen(msg));
+}
+
+static void print_subtest_result(int passed) {
+    if (passed) {
+        msg = "  -> PASSED\n";
+    } else {
+        msg = "  -> FAILED\n";
+    }
+    write(1, msg, strlen(msg));
+}
+
+/* ============================================================
+ *                    SUBTEST IMPLEMENTATIONS
+ * ============================================================ */
+
+/**
+ * Subtest 1 & 2: Create maximum threads and verify limit
+ * Note: MAX_THREADS_PER_PROCESS (5) includes the master thread,
+ *       so we can only create 4 additional threads (slots 2-5).
+ */
+void subtest_max_threads(int *passed) {
+    /* Master already uses 1 slot, so we can create MAX - 1 new threads */
+    int max_new_threads = MAX_THREADS_PER_PROCESS - 1;
+
+    print_subtest_header(1, "Create maximum additional threads (4) and verify limit");
+
+    clear_all_flags();
+
+    int tids[MAX_THREADS_PER_PROCESS];
+    int flag_indices[MAX_THREADS_PER_PROCESS];
+    int created = 0;
+
+    write_current_info();
+    msg = "Creating up to ";
+    write(1, msg, strlen(msg));
+    itoa(max_new_threads, buffer);
+    write(1, buffer, strlen(buffer));
+    msg = " additional threads (master uses 1 slot)...\n";
+    write(1, msg, strlen(msg));
+
+    /* Try to create MAX_THREADS_PER_PROCESS threads, expect only max_new_threads to succeed */
+    for (int i = 0; i < MAX_THREADS_PER_PROCESS; i++) {
+        flag_indices[i] = i;
+        tids[i] = ThreadCreate(minimal_thread_func, &flag_indices[i]);
+
+        if (tids[i] > 0) {
+            created++;
+            write_current_info();
+            msg = "  Created thread TID ";
+            write(1, msg, strlen(msg));
+            itoa(tids[i], buffer);
+            write(1, buffer, strlen(buffer));
+            msg = "\n";
+            write(1, msg, strlen(msg));
+        }
+    }
+
+    msg = "  Created ";
+    write(1, msg, strlen(msg));
+    itoa(created, buffer);
+    write(1, buffer, strlen(buffer));
+    msg = "/";
+    write(1, msg, strlen(msg));
+    itoa(max_new_threads, buffer);
+    write(1, buffer, strlen(buffer));
+    msg = " additional threads\n";
+    write(1, msg, strlen(msg));
+
+    /* Expect exactly max_new_threads (4) to be created */
+    int test1_passed = (created == max_new_threads);
+    print_subtest_result(test1_passed);
+
+    thread_subtests_run++;
+    if (test1_passed) thread_subtests_passed++;
+
+    /* Wait for all threads to complete */
+    wait_for_flags(created);
+
+    /* Subtest 2: Verify that after threads exit, we can create new ones again */
+    print_subtest_header(2, "Verify thread limit enforcement after cleanup");
+
+    /* All threads should have exited, now create max again */
+    clear_all_flags();
+    created = 0;
+    for (int i = 0; i < max_new_threads; i++) {
+        flag_indices[i] = i;
+        tids[i] = ThreadCreate(simple_thread_func, &flag_indices[i]);
+        if (tids[i] > 0) created++;
+    }
+
+    /* Now try to create one more - should fail (we have master + max_new_threads = 5 total) */
+    int extra_flag = 7;
+    int extra_tid = ThreadCreate(simple_thread_func, &extra_flag);
+
+    write_current_info();
+    if (extra_tid < 0) {
+        msg = "  Correctly rejected 5th additional thread (returned ";
+        write(1, msg, strlen(msg));
+        itoa(extra_tid, buffer);
+        write(1, buffer, strlen(buffer));
+        msg = ")\n";
+        write(1, msg, strlen(msg));
+        *passed = 1;
+    } else {
+        msg = "  ERROR: Created extra thread with TID ";
+        write(1, msg, strlen(msg));
+        itoa(extra_tid, buffer);
+        write(1, buffer, strlen(buffer));
+        msg = " (should have failed)\n";
+        write(1, msg, strlen(msg));
+        *passed = 0;
+    }
+
+    print_subtest_result(*passed);
+    thread_subtests_run++;
+    if (*passed) thread_subtests_passed++;
+
+    /* Wait for created threads to complete */
+    wait_for_flags(created);
+}
+
+/**
+ * Subtest 3: TID reuse after thread deletion
+ */
+void subtest_tid_reuse(int *passed) {
+    print_subtest_header(3, "TID reuse after thread deletion");
+
+    clear_all_flags();
+
+    /* Create a thread, let it exit, create another - TID should be reused */
+    int flag0 = 0;
+    int first_tid = ThreadCreate(minimal_thread_func, &flag0);
+
+    write_current_info();
+    msg = "  First thread created with TID ";
+    write(1, msg, strlen(msg));
+    itoa(first_tid, buffer);
+    write(1, buffer, strlen(buffer));
+    msg = "\n";
+    write(1, msg, strlen(msg));
+
+    /* Wait for thread to complete */
+    wait_for_flag(0);
+
+    /* Small delay to ensure cleanup */
+    waitTicks(MIN_WORK_TIME);
+
+    /* Create another thread */
+    clear_all_flags();
+    int flag1 = 0;
+    int second_tid = ThreadCreate(minimal_thread_func, &flag1);
+
+    write_current_info();
+    msg = "  Second thread created with TID ";
+    write(1, msg, strlen(msg));
+    itoa(second_tid, buffer);
+    write(1, buffer, strlen(buffer));
+    msg = "\n";
+    write(1, msg, strlen(msg));
+
+    /* Wait for completion */
+    wait_for_flag(0);
+
+    /* Check if TID was reused (should be same or another freed TID) */
+    if (second_tid > 0) {
+        if (second_tid == first_tid) {
+            msg = "  TID ";
+            write(1, msg, strlen(msg));
+            itoa(first_tid, buffer);
+            write(1, buffer, strlen(buffer));
+            msg = " was reused\n";
+            write(1, msg, strlen(msg));
+        } else {
+            msg = "  Different TID used (still valid - TIDs are being freed)\n";
+            write(1, msg, strlen(msg));
+        }
+        *passed = 1;
+    } else {
+        msg = "  ERROR: Could not create second thread\n";
+        write(1, msg, strlen(msg));
+        *passed = 0;
+    }
+
+    print_subtest_result(*passed);
+    thread_subtests_run++;
+    if (*passed) thread_subtests_passed++;
+}
+
+/**
+ * Subtest 4: Process terminates when last thread exits
+ * This must be run in a child process since it terminates the process.
+ */
+void subtest_last_thread_exits(void) {
+    print_subtest_header(4, "Process terminates when last thread exits");
+
+    write_current_info();
+    msg = "  Creating child process to test last thread exit...\n";
+    write(1, msg, strlen(msg));
+
+    int pid = fork();
+
+    if (pid == 0) {
+        /* Child process - we are the only thread initially */
+        write_current_info();
+        msg = "  Child: I am the only thread, calling ThreadExit()\n";
+        write(1, msg, strlen(msg));
+
+        msg = "  -> PASSED (if this prints and process exits)\n";
+        write(1, msg, strlen(msg));
+
+        /* This should terminate the process */
+        ThreadExit();
+
+        /* Should never reach here */
+        msg = "  -> FAILED: Code after ThreadExit executed!\n";
+        write(1, msg, strlen(msg));
+        exit();
+
+    } else if (pid > 0) {
+        /* Parent waits for child to complete */
+        waitTicks(MEDIUM_WORK_TIME);
+
+        write_current_info();
+        msg = "  Parent: Child process should have terminated\n";
+        write(1, msg, strlen(msg));
+
+        thread_subtests_run++;
+        thread_subtests_passed++; /* If we got here, child exited properly */
+    } else {
+        msg = "  -> FAILED: Fork failed\n";
+        write(1, msg, strlen(msg));
+        thread_subtests_run++;
+    }
+}
+
+/**
+ * Subtest 5: Master thread reassignment when current master exits
+ */
+void subtest_master_reassignment(void) {
+    print_subtest_header(5, "Master thread reassignment when master exits");
+
+    write_current_info();
+    msg = "  Creating child process to test master reassignment...\n";
+    write(1, msg, strlen(msg));
+
+    int pid = fork();
+
+    if (pid == 0) {
+        /* Child process - we are the master thread */
+        clear_all_flags();
+
+        write_current_info();
+        msg = "  Child (Master): Creating survivor thread\n";
+        write(1, msg, strlen(msg));
+
+        int flag_idx = 0;
+        int survivor_tid = ThreadCreate(survivor_thread_func, &flag_idx);
+
+        if (survivor_tid > 0) {
+            write_current_info();
+            msg = "  Child (Master): Created survivor TID ";
+            write(1, msg, strlen(msg));
+            itoa(survivor_tid, buffer);
+            write(1, buffer, strlen(buffer));
+            msg = "\n";
+            write(1, msg, strlen(msg));
+
+            /* Wait for survivor to be ready */
+            wait_for_flag(0);
+
+            write_current_info();
+            msg = "  Child (Master): Exiting, survivor should become master\n";
+            write(1, msg, strlen(msg));
+
+            msg = "  -> PASSED (if survivor continues and process eventually exits)\n";
+            write(1, msg, strlen(msg));
+
+            /* Master exits - survivor should take over */
+            ThreadExit();
+
+            /* Should never reach here */
+            msg = "  -> FAILED: Code after ThreadExit executed!\n";
+            write(1, msg, strlen(msg));
+        } else {
+            msg = "  -> FAILED: Could not create survivor thread\n";
+            write(1, msg, strlen(msg));
+        }
+        exit();
+
+    } else if (pid > 0) {
+        /* Parent waits for child to complete */
+        waitTicks(LONG_WORK_TIME);
+
+        write_current_info();
+        msg = "  Parent: Child process should have completed\n";
+        write(1, msg, strlen(msg));
+
+        thread_subtests_run++;
+        thread_subtests_passed++; /* If we got here, reassignment worked */
+    } else {
+        msg = "  -> FAILED: Fork failed\n";
+        write(1, msg, strlen(msg));
+        thread_subtests_run++;
+    }
+}
+
+/* Thread that works for a while then exits - for fork test */
+static void long_work_thread_func(void *arg) {
+    int flag_index = *(int *)arg;
+
+    write_current_info();
+    msg = "Secondary thread started, working...\n";
+    write(1, msg, strlen(msg));
+
+    /* Signal that we've started */
+    set_flag(flag_index);
+
+    /* Work for a while - this thread should NOT be copied to child */
+    int start = gettime();
+    while (gettime() - start < LONG_WORK_TIME) {
+        /* Working... */
+    }
+
+    write_current_info();
+    msg = "Secondary thread finished work, exiting\n";
+    write(1, msg, strlen(msg));
+
+    ThreadExit();
+}
+
+/**
+ * Subtest 6: Fork copies only current thread
+ * This test creates a secondary thread, then forks. The child should only
+ * have the calling thread, not the secondary thread.
+ */
+void subtest_fork_single_thread(int *passed) {
+    print_subtest_header(6, "Fork copies only current thread");
+
+    clear_all_flags();
+
+    /* Create a secondary thread that will work during fork */
+    write_current_info();
+    msg = "  Creating secondary thread before fork...\n";
+    write(1, msg, strlen(msg));
+
+    int flag_idx = 0;
+    int secondary_tid = ThreadCreate(long_work_thread_func, &flag_idx);
+
+    if (secondary_tid <= 0) {
+        msg = "  -> FAILED: Could not create secondary thread\n";
+        write(1, msg, strlen(msg));
+        *passed = 0;
+        print_subtest_result(*passed);
+        thread_subtests_run++;
+        return;
+    }
+
+    /* Wait for secondary thread to signal it has started */
+    wait_for_flag(0);
+
+    write_current_info();
+    msg = "  Secondary thread TID ";
+    write(1, msg, strlen(msg));
+    itoa(secondary_tid, buffer);
+    write(1, buffer, strlen(buffer));
+    msg = " is working, now forking...\n";
+    write(1, msg, strlen(msg));
+
+    int child_pid = fork();
+
+    if (child_pid == 0) {
+        /* Child process - should only have current thread, not the secondary one */
+        /* Child starts fresh with 1 thread (master), so can create 4 more */
+        int max_new_threads = MAX_THREADS_PER_PROCESS - 1;
+
+        write_current_info();
+        msg = "  Child: I should be the only thread (TID ";
+        write(1, msg, strlen(msg));
+        itoa(gettid(), buffer);
+        write(1, buffer, strlen(buffer));
+        msg = ")\n";
+        write(1, msg, strlen(msg));
+
+        /* Try to create threads - if fork only copied us, we should be able to create max_new_threads */
+        int can_create = 0;
+        int test_tids[MAX_THREADS_PER_PROCESS];
+        int test_flags[MAX_THREADS_PER_PROCESS];
+
+        for (int i = 0; i < max_new_threads; i++) {
+            test_flags[i] = i;
+            test_tids[i] = ThreadCreate(minimal_thread_func, &test_flags[i]);
+            if (test_tids[i] > 0) can_create++;
+        }
+
+        msg = "  Child: Created ";
+        write(1, msg, strlen(msg));
+        itoa(can_create, buffer);
+        write(1, buffer, strlen(buffer));
+        msg = " threads (expected ";
+        write(1, msg, strlen(msg));
+        itoa(max_new_threads, buffer);
+        write(1, buffer, strlen(buffer));
+        msg = ")\n";
+        write(1, msg, strlen(msg));
+
+        if (can_create == max_new_threads) {
+            msg = "  -> PASSED (fork copied only current thread)\n";
+            write(1, msg, strlen(msg));
+        } else {
+            msg = "  -> FAILED (fork may have copied other threads)\n";
+            write(1, msg, strlen(msg));
+        }
+
+        /* Wait for threads to complete and exit */
+        waitTicks(MEDIUM_WORK_TIME);
+        exit();
+
+    } else if (child_pid > 0) {
+        /* Parent - wait for child and our secondary thread */
+        write_current_info();
+        msg = "  Parent: Forked child PID ";
+        write(1, msg, strlen(msg));
+        itoa(child_pid, buffer);
+        write(1, buffer, strlen(buffer));
+        msg = "\n";
+        write(1, msg, strlen(msg));
+
+        /* Wait for child to complete its test and for secondary thread to finish */
+        waitTicks(LONG_WORK_TIME + MEDIUM_WORK_TIME);
+
+        write_current_info();
+        msg = "  Parent: Test completed\n";
+        write(1, msg, strlen(msg));
+
+        *passed = 1; /* Success if we reach here */
+        print_subtest_result(*passed);
+        thread_subtests_run++;
+        if (*passed) thread_subtests_passed++;
+
+    } else {
+        msg = "  -> FAILED: Fork failed\n";
+        write(1, msg, strlen(msg));
+        *passed = 0;
+        print_subtest_result(*passed);
+        thread_subtests_run++;
+    }
+}
+
+/* ============================================================
+ *                    MAIN TEST FUNCTIONS
+ * ============================================================ */
+
+void thread_tests(void) {
+    print_test_header("THREAD TESTS");
+
+    thread_subtests_run = 0;
+    thread_subtests_passed = 0;
+
+    write_current_info();
+    msg = "Starting thread test suite...\n";
+    write(1, msg, strlen(msg));
+
+    int result;
+
+    /* Subtest 1 & 2: Max threads and limit enforcement */
+    subtest_max_threads(&result);
+
+    /* Subtest 3: TID reuse */
+    subtest_tid_reuse(&result);
+
+    /* Subtest 4: Last thread exits -> process terminates */
+    subtest_last_thread_exits();
+
+    /* Subtest 5: Master thread reassignment */
+    subtest_master_reassignment();
+
+    /* Subtest 6: Fork copies only current thread */
+    subtest_fork_single_thread(&result);
+
+    /* Print thread test summary */
+    msg = "\n========================================\n";
+    write(1, msg, strlen(msg));
+    msg = "[THREAD_TESTS] Summary: ";
+    write(1, msg, strlen(msg));
+    itoa(thread_subtests_passed, buffer);
+    write(1, buffer, strlen(buffer));
+    msg = "/";
+    write(1, msg, strlen(msg));
+    itoa(thread_subtests_run, buffer);
+    write(1, buffer, strlen(buffer));
+    msg = " subtests passed\n";
+    write(1, msg, strlen(msg));
+    msg = "========================================\n";
+    write(1, msg, strlen(msg));
+
+    int all_passed = (thread_subtests_passed == thread_subtests_run);
+    print_test_result("Thread Tests", all_passed);
+}
+
+void execute_project_tests(void) {
+    msg = "\n=========================================\n";
+    write(1, msg, strlen(msg));
+    msg = "      PROJECT TEST SUITE                 \n";
+    write(1, msg, strlen(msg));
+    msg = "=========================================\n\n";
+    write(1, msg, strlen(msg));
+
+    write_current_info();
+    msg = "Coordinator thread starting tests...\n\n";
+    write(1, msg, strlen(msg));
+
+#if THREAD_TEST
+    RESET_ERRNO();
+    thread_tests();
+#endif
+
+    msg = "\n=========================================\n";
+    write(1, msg, strlen(msg));
+    msg = "      ALL PROJECT TESTS COMPLETED        \n";
+    write(1, msg, strlen(msg));
+    msg = "=========================================\n\n";
+    write(1, msg, strlen(msg));
+
+#if IDLE_SWITCH_TEST
+    write_current_info();
+    msg = "Terminating init process. System will switch to idle.\n";
+    write(1, msg, strlen(msg));
+    exit();
+#endif
 }

--- a/project/project_test.c
+++ b/project/project_test.c
@@ -143,7 +143,8 @@ static void survivor_thread_func(void *arg) {
 
     /* Work for a while - we should become master */
     int start = gettime();
-    while (gettime() - start < MEDIUM_WORK_TIME) { }
+    while (gettime() - start < MEDIUM_WORK_TIME) {
+    }
 
     write_current_info();
     msg = "Survivor thread: I am now master (hopefully), exiting process\n";
@@ -570,7 +571,8 @@ void subtest_fork_single_thread(int *passed) {
         msg = ")\n";
         write(1, msg, strlen(msg));
 
-        /* Try to create threads - if fork only copied us, we should be able to create max_new_threads */
+        /* Try to create threads - if fork only copied us, we should be able to create
+         * max_new_threads */
         int can_create = 0;
         int test_tids[MAX_THREADS_PER_PROCESS];
         int test_flags[MAX_THREADS_PER_PROCESS];

--- a/project/sched.c
+++ b/project/sched.c
@@ -56,7 +56,7 @@ int allocate_DIR(struct task_struct *task) {
 void cpu_idle(void) {
 
     __asm__ __volatile__("sti" : : : "memory");
-    printk_color_fmt(INFO_COLOR, "[IDLE] Idle task started. Current PID=%d, TID=%d\n",
+    printk_color_fmt(INFO_COLOR, "DEBUG->[IDLE] Idle task started. Current PID=%d, TID=%d\n",
                      current()->PID, current()->TID);
     while (1) {
         ;
@@ -302,7 +302,10 @@ void scheduler(void) {
     update_sched_data_rr();
 
     if (needs_sched_rr()) {
-        update_process_state_rr(current_task, &readyqueue);
+        /* Only add to ready queue if NOT blocked (blocked tasks are already in blocked queue) */
+        if (current_task->status != ST_BLOCKED) {
+            update_process_state_rr(current_task, &readyqueue);
+        }
         sched_next_rr();
     }
 }
@@ -311,8 +314,8 @@ void scheduler(void) {
 
 void printDebugInfoSched(int from_pid, int from_tid, int to_pid, int to_tid) {
     printk_color_fmt(INFO_COLOR,
-                     "[SCHED] switch from PID %d TID %d to PID %d TID %d and ready: ", from_pid,
-                     from_tid, to_pid, to_tid);
+                     "DEBUG->[SCHED] switch from PID %d TID %d to PID %d TID %d and ready: ",
+                     from_pid, from_tid, to_pid, to_tid);
     if (list_empty(&readyqueue)) {
         printk_color_fmt(WARNING_COLOR, "empty\n");
     } else {

--- a/project/sys.c
+++ b/project/sys.c
@@ -58,7 +58,8 @@ int sys_fork() {
     int PID = -1;
 
 #if DEBUG_INFO_FORK
-    printk_color_fmt(INFO_COLOR, "[FORK] PID %d calling fork\n", current_task->PID);
+    printk_color_fmt(INFO_COLOR, "DEBUG->[FORK] PID %d TID %d calling fork\n", current_task->PID,
+                     current_task->TID);
 #endif
 
     /*=== STEP a: Get a free task_struct ===*/
@@ -113,8 +114,8 @@ int sys_fork() {
     }
 
     /*=== STEP f: Inherit user data === */
-    // Temporarily map child's pages in parent's address space
-    int temp_pages = NUM_PAG_KERNEL + NUM_PAG_CODE + NUM_PAG_DATA; // Free pages
+    /* Use FORK_TEMP_MAPPING_PAGE at end of address space to avoid conflicts with thread stacks */
+    unsigned int temp_pages = FORK_TEMP_MAPPING_PAGE;
 
     for (int page = 0; page < NUM_PAG_DATA; page++) {
         /* e.ii) Assign new frames for user data+stack */
@@ -189,7 +190,8 @@ int sys_fork() {
     list_add_tail(&child_task->list, &readyqueue);
 
 #if DEBUG_INFO_FORK
-    printk_color_fmt(INFO_COLOR, "[FORK] PID %d created child PID %d\n", current_task->PID, PID);
+    printk_color_fmt(INFO_COLOR, "DEBUG->[FORK] PID %d TID %d created child PID %d TID %d\n",
+                     current_task->PID, current_task->TID, PID, PID * 10 + 1);
 #endif
 
     /* === STEP l: Return child PID === */
@@ -227,7 +229,7 @@ int sys_gettime() {
 
 void sys_exit() {
 #if DEBUG_INFO_EXIT
-    printk_color_fmt(INFO_COLOR, "[EXIT] PID %d TID %d calling exit\n", current_task->PID,
+    printk_color_fmt(INFO_COLOR, "DEBUG->[EXIT] PID %d TID %d calling exit\n", current_task->PID,
                      current_task->TID);
 #endif
     struct task_struct *master = current_task->master_thread;
@@ -404,7 +406,7 @@ static void release_thread_stack(struct task_struct *thread) {
 
 int sys_create_thread(void (*function)(void *), void *parameter, void (*exit_routine)(void)) {
 #if DEBUG_INFO_THREAD_CREATE
-    printk_color_fmt(INFO_COLOR, "[THREAD_CREATE] PID %d TID %d creating new thread\n",
+    printk_color_fmt(INFO_COLOR, "DEBUG->[THREAD_CREATE] PID %d TID %d creating new thread\n",
                      current_task->PID, current_task->TID);
 #endif
 
@@ -514,7 +516,7 @@ int sys_create_thread(void (*function)(void *), void *parameter, void (*exit_rou
     list_add_tail(&new_thread->list, &readyqueue);
 
 #if DEBUG_INFO_THREAD_CREATE
-    printk_color_fmt(INFO_COLOR, "[THREAD_CREATE] PID %d created TID %d\n", new_thread->PID,
+    printk_color_fmt(INFO_COLOR, "DEBUG->[THREAD_CREATE] PID %d created TID %d\n", new_thread->PID,
                      new_thread->TID);
 #endif
 
@@ -526,7 +528,8 @@ void sys_exit_thread(void) {
     struct task_struct *master = thread->master_thread;
 
 #if DEBUG_INFO_THREAD_EXIT
-    printk_color_fmt(INFO_COLOR, "[THREAD_EXIT] PID %d TID %d exiting (master has %d threads)\n",
+    printk_color_fmt(INFO_COLOR,
+                     "DEBUG->[THREAD_EXIT] PID %d TID %d exiting (master has %d threads)\n",
                      thread->PID, thread->TID, master->thread_count);
 #endif
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a full thread test suite and updates kernel threading (stack mapping, create/exit, fork temp mappings/logs) with a scheduler fix and Makefile/doc path tweaks.
> 
> - **Tests**:
>   - **Thread suite**: Implement `thread_tests` with subtests for max threads/limit, TID reuse, last-thread exit, master reassignment, and fork-only-current-thread in `project/project_test.c`.
>   - **Utilities**: Add sync flags (`clear_all_flags`, `set_flag`, `wait_for_flag`), timing constants, and helper thread funcs; update `project/include/project_test.h` accordingly.
> - **Kernel**:
>   - **Scheduler**: In `scheduler()` avoid enqueueing if `ST_BLOCKED`; debug message text updated.
>   - **Fork/threads** (`project/sys.c`):
>     - Use `FORK_TEMP_MAPPING_PAGE` for copying data; richer debug logs (include PID/TID).
>     - Initialize child as single-threaded with TID `PID*10+1`; add to `readyqueue`.
>     - Implement per-thread stack setup in `sys_create_thread` using `TEMP_STACK_MAPPING_PAGE`; manage TID slots and thread lists; improved `sys_exit_thread` (last-thread exit, master reassignment); add `grow_user_stack` and stack release helpers.
>   - **Headers**: In `project/include/sys.h` define `TEMP_STACK_MAPPING_PAGE` and `FORK_TEMP_MAPPING_PAGE`, thread stack constants; in `project/include/debug.h` disable most debug flags.
> - **Build/Docs**:
>   - `Makefile`: rename backup target paths to `project_versions`; update Doxygen paths to `docs/doxygen/project`.
> - **Misc**: `.gitignore` adds `.cache` and `*.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a88ae4c90168de70c218645fafd37df9e5c1a521. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->