### PR TITLE
M1 thread support

### DIFF
--- a/docs/project_milestones/M1_thread_support.txt
+++ b/docs/project_milestones/M1_thread_support.txt
@@ -1,0 +1,63 @@
+================================================================================
+                     MILESTONE 1: THREAD SUPPORT IN ZEOS
+================================================================================
+
+1. SYSTEM CALLS IMPLEMENTADAS
+-----------------------------
+
+int ThreadCreate(void (*function)(void* arg), void* parameter);
+  - Crea un nuevo thread que ejecuta function(parameter)
+  - Stack inicial: 1 página, con crecimiento dinámico via page faults
+  - Usa thread_entry_wrapper para garantizar que ThreadExit siempre se llame
+
+void ThreadExit(void);
+  - Termina el thread actual y libera su stack
+  - Si es el último thread del proceso, termina el proceso completo
+
+2. ESQUEMA DE TIDs
+------------------
+
+TID = PID * 10 + slot (0-9)
+  - 10 threads máximo por proceso
+  - Idle: TID = 0
+  - Init (PID 1): TIDs 10-19
+  - Procesos hijos: TIDs PID*10 hasta PID*10+9
+
+3. THREAD WRAPPER
+-----------------
+
+El thread_entry_wrapper (sys_call_wrappers.S) envuelve la función del usuario:
+  1. Kernel configura thread para empezar en thread_entry_wrapper
+  2. Stack contiene: [retaddr][function][parameter]
+  3. wrapper llama function(parameter)
+  4. Cuando function retorna, wrapper llama ThreadExit automáticamente
+
+Esto garantiza que ThreadExit siempre se llame aunque el programador lo olvide.
+
+4. USER STACKS
+--------------
+
+- Cada thread tiene su propio stack fuera de la zona data+stack
+- THREAD_STACK_REGION_PAGES = 8 páginas reservadas por thread
+- THREAD_STACK_INITIAL_PAGES = 1 página mapeada inicialmente
+- Crecimiento dinámico: page fault en gap → grow_user_stack() asigna página
+- El primer thread de init también tiene stack dedicado
+
+5. MODIFICACIONES EN FORK
+-------------------------
+
+- Fork solo copia el thread que llama (no los otros threads del proceso)
+- El hijo empieza con thread_count = 1 y tid_slots[] inicializado
+- Se copia el user stack del thread padre al hijo
+
+6. ARCHIVOS MODIFICADOS
+-----------------------
+
+include/sched.h    - MAX_TIDS_PER_PROCESS=10, campos thread en task_struct
+include/sys.h      - Constantes THREAD_STACK_*, prototipo sys_create_thread
+sched.c            - init_tid_slots, allocate_tid, free_tid, init_task1 con stack
+sys.c              - sys_fork, sys_create_thread, sys_exit_thread, grow_user_stack
+sys_call_wrappers.S - thread_entry_wrapper, ThreadCreate pasa wrapper al kernel
+interrupt.c        - pageFault_routine llama grow_user_stack
+
+================================================================================

--- a/docs/project_milestones/M1_thread_support.txt
+++ b/docs/project_milestones/M1_thread_support.txt
@@ -9,55 +9,62 @@ int ThreadCreate(void (*function)(void* arg), void* parameter);
   - Crea un nuevo thread que ejecuta function(parameter)
   - Stack inicial: 1 página, con crecimiento dinámico via page faults
   - Usa thread_entry_wrapper para garantizar que ThreadExit siempre se llame
+  - Retorna TID del nuevo thread o error negativo (-ENOMEM si no hay tasks)
 
 void ThreadExit(void);
   - Termina el thread actual y libera su stack
   - Si es el último thread del proceso, termina el proceso completo
+  - Si el thread es master, reasigna master al siguiente thread activo
 
 2. ESQUEMA DE TIDs
 ------------------
 
 TID = PID * 10 + slot (0-9)
-  - 10 threads máximo por proceso
-  - Idle: TID = 0
+  - 10 threads máximo por proceso (MAX_TIDS_PER_PROCESS)
+  - Idle: TID = 0 (único thread del proceso idle)
   - Init (PID 1): TIDs 10-19
   - Procesos hijos: TIDs PID*10 hasta PID*10+9
+  - tid_slots[10] en task_struct: 1=usado, 0=libre
 
-3. THREAD WRAPPER
------------------
+3. THREAD ENTRY WRAPPER
+-----------------------
 
 El thread_entry_wrapper (sys_call_wrappers.S) envuelve la función del usuario:
-  1. Kernel configura thread para empezar en thread_entry_wrapper
-  2. Stack contiene: [retaddr][function][parameter]
-  3. wrapper llama function(parameter)
+  1. Kernel configura EIP del nuevo thread a thread_entry_wrapper
+  2. Stack usuario contiene: [retaddr(0)][function][parameter]
+  3. wrapper: movl 4(%esp),%eax; movl 8(%esp),%ecx; pushl %ecx; call *%eax
   4. Cuando function retorna, wrapper llama ThreadExit automáticamente
 
 Esto garantiza que ThreadExit siempre se llame aunque el programador lo olvide.
+El kernel usa ret_from_fork para la transición kernel→user del nuevo thread.
 
 4. USER STACKS
 --------------
 
 - Cada thread tiene su propio stack fuera de la zona data+stack
-- THREAD_STACK_REGION_PAGES = 8 páginas reservadas por thread
+- THREAD_STACK_REGION_PAGES = 8 páginas reservadas por thread (gap incluido)
 - THREAD_STACK_INITIAL_PAGES = 1 página mapeada inicialmente
 - Crecimiento dinámico: page fault en gap → grow_user_stack() asigna página
-- El primer thread de init también tiene stack dedicado
+- El primer thread de init también tiene stack dedicado (no usa data+stack)
+- find_free_stack_region() busca región libre en page directory
 
 5. MODIFICACIONES EN FORK
 -------------------------
 
 - Fork solo copia el thread que llama (no los otros threads del proceso)
 - El hijo empieza con thread_count = 1 y tid_slots[] inicializado
-- Se copia el user stack del thread padre al hijo
+- Se copia el user stack del thread padre al hijo usando mapping temporal
+- FORK_TEMP_MAPPING_PAGE evita conflictos con regiones de thread stacks
 
 6. ARCHIVOS MODIFICADOS
 -----------------------
 
-include/sched.h    - MAX_TIDS_PER_PROCESS=10, campos thread en task_struct
-include/sys.h      - Constantes THREAD_STACK_*, prototipo sys_create_thread
-sched.c            - init_tid_slots, allocate_tid, free_tid, init_task1 con stack
-sys.c              - sys_fork, sys_create_thread, sys_exit_thread, grow_user_stack
+include/sched.h     - MAX_TIDS_PER_PROCESS=10, campos thread en task_struct
+include/sys.h       - Constantes THREAD_STACK_*, prototipo sys_create_thread
+include/libc.h      - thread_entry_wrapper declaración
+sched.c             - init_tid_slots, allocate_tid, free_tid, init_task1 con stack
+sys.c               - sys_fork, sys_create_thread, sys_exit_thread, grow_user_stack
 sys_call_wrappers.S - thread_entry_wrapper, ThreadCreate pasa wrapper al kernel
-interrupt.c        - pageFault_routine llama grow_user_stack
+interrupt.c         - pageFault_routine llama grow_user_stack
 
 ================================================================================

--- a/project/include/io.h
+++ b/project/include/io.h
@@ -40,6 +40,11 @@
 #define WARNING_COLOR MAKE_COLOR(BLACK, YELLOW)
 #define INFO_COLOR MAKE_COLOR(BLACK, LIGHT_BLUE)
 
+/* VGA text mode constants */
+#define NUM_COLUMNS 80            /* Number of columns in text mode */
+#define NUM_ROWS 25               /* Number of rows in text mode */
+#define VIDEO_MEMORY_BASE 0xb8000 /* Base address of VGA text mode video memory */
+
 /** Screen functions **/
 /**********************/
 

--- a/project/include/libc.h
+++ b/project/include/libc.h
@@ -129,20 +129,50 @@ int unblock(int pid);
  * @brief Create a new thread.
  *
  * This function creates a new thread that executes the given function
- * with the provided parameter. A wrapper ensures ThreadExit is called.
+ * with the provided parameter. Internally, ThreadCreate passes the address
+ * of thread_entry_wrapper to the kernel, which sets up the new thread to
+ * start execution at that wrapper. The wrapper then calls function(parameter)
+ * and ensures ThreadExit is always called when the function returns.
  *
  * @param function Pointer to the function the thread will execute.
  * @param parameter Parameter to pass to the thread function.
- * @return Thread ID on success, -1 on error with errno set.
+ * @return Thread ID (TID) on success, -1 on error with errno set to:
+ *         - EINVAL: Invalid function pointer
+ *         - ENOMEM: No available task structures or TID slots
+ *         - EAGAIN: Could not allocate memory for thread stack
  */
 int ThreadCreate(void (*function)(void *), void *parameter);
 
 /**
  * @brief Exit the current thread.
  *
- * This function terminates the calling thread. Must be called to
- * properly clean up thread resources.
+ * This function terminates the calling thread and frees its resources
+ * (user stack, TID slot). If this is the last thread in the process,
+ * the entire process is terminated.
+ *
+ * Note: Returning from a thread function without calling ThreadExit
+ * would crash the system, but thread_entry_wrapper ensures ThreadExit
+ * is always called automatically.
  */
 void ThreadExit(void);
+
+/**
+ * @brief Thread entry wrapper function (internal use).
+ *
+ * This function is the actual entry point for new threads. The kernel
+ * sets up the thread's initial EIP to point to this wrapper, with the
+ * user stack containing:
+ *   - [esp+0]: unused return address
+ *   - [esp+4]: function pointer
+ *   - [esp+8]: parameter
+ *
+ * The wrapper:
+ *   1. Extracts function and parameter from the stack
+ *   2. Calls function(parameter)
+ *   3. Calls ThreadExit when the function returns
+ *
+ * This guarantees ThreadExit is always called, even if the user forgets.
+ */
+void thread_entry_wrapper(void);
 
 #endif /* __LIBC_H__ */

--- a/project/include/libc.h
+++ b/project/include/libc.h
@@ -11,6 +11,9 @@
 
 #include <stats.h>
 
+/* Buffer size for prints() formatting */
+#define PRINTF_BUFFER_SIZE 256
+
 /**
  * @brief Convert integer to ASCII string.
  *
@@ -174,5 +177,25 @@ void ThreadExit(void);
  * This guarantees ThreadExit is always called, even if the user forgets.
  */
 void thread_entry_wrapper(void);
+
+/**
+ * @brief Formatted print to stdout (user space printf).
+ *
+ * This function formats a string with variable arguments and writes
+ * it to stdout. Similar to printf but simplified for ZeOS user space.
+ * Supports format specifiers: %d (int), %s (string), %c (char), %% (literal %).
+ *
+ * @param fmt Format string with optional format specifiers.
+ * @param ... Variable arguments matching format specifiers.
+ */
+void prints(const char *fmt, ...);
+
+/**
+ * @brief Print error message based on errno.
+ *
+ * This function prints an error message corresponding to the current
+ * value of errno.
+ */
+void perror(void);
 
 #endif /* __LIBC_H__ */

--- a/project/include/mm_address.h
+++ b/project/include/mm_address.h
@@ -42,6 +42,9 @@
 /* Logical address where user space starts (1MB) */
 #define L_USER_START 0x100000
 
+/* Physical address where user code starts (1MB) */
+#define PH_USER_START 0x100000
+
 /* Initial ESP for user processes (top of data segment - 16 bytes) */
 #define USER_ESP L_USER_START + (NUM_PAG_DATA)*0x1000 - 16
 

--- a/project/include/project_test.h
+++ b/project/include/project_test.h
@@ -30,10 +30,10 @@
 #define MEDIUM_WORK_TIME 1500 /* 1.5 seconds */
 #define LONG_WORK_TIME 3000   /* 3 seconds */
 
-#define MAX_THREADS_PER_PROCESS 5 /* Maximum threads per process */
+#define MAX_THREADS_PER_PROCESS 10 /* Maximum threads per process (TIDs X0-X9) */
 
 /* Synchronization flags - shared between threads */
-#define MAX_SYNC_FLAGS 8
+#define MAX_SYNC_FLAGS 10
 
 /**
  * @brief Execute all thread test suites.

--- a/project/include/project_test.h
+++ b/project/include/project_test.h
@@ -13,7 +13,7 @@
 
 // clang-format off
 #define THREAD_TEST         1   /* Enable/disable thread tests */
-#define IDLE_SWITCH_TEST    0   /* Test idle switch (exits init) */
+#define IDLE_SWITCH_TEST    1   /* Test idle switch (exits init) */
 // clang-format on
 
 /* Reset errno macro */
@@ -48,12 +48,13 @@ void execute_project_tests(void);
  * @brief Main thread test suite.
  *
  * This function runs all thread tests:
- * - Subtest 1: Create threads up to max limit (5 per process)
+ * - Subtest 1: Create threads up to max limit (10 per process)
  * - Subtest 2: Verify creation fails when limit reached
  * - Subtest 3: TID reuse after thread deletion
  * - Subtest 4: Process termination when last thread exits
  * - Subtest 5: Master thread reassignment when current master exits
  * - Subtest 6: Fork copies only current thread
+ * - Subtest 7: Thread wrapper calls ThreadExit on function return
  */
 void thread_tests(void);
 
@@ -88,6 +89,15 @@ void subtest_master_reassignment(void);
  * @param passed Pointer to store result (1 = passed, 0 = failed)
  */
 void subtest_fork_single_thread(int *passed);
+
+/**
+ * @brief Test that thread wrapper calls ThreadExit on function return.
+ *
+ * Creates a thread that returns without calling ThreadExit explicitly.
+ * The wrapper should automatically call ThreadExit, preventing a crash.
+ * @param passed Pointer to store result (1 = passed, 0 = failed)
+ */
+void subtest_wrapper_calls_exit(int *passed);
 
 /* ---- Utility Functions ---- */
 

--- a/project/include/sched.h
+++ b/project/include/sched.h
@@ -14,7 +14,7 @@
 #include <types.h>
 
 /* Maximum number of tasks in the system */
-#define NR_TASKS 10
+#define NR_TASKS 25
 
 /* Size of the kernel stack for each process in words */
 #define KERNEL_STACK_SIZE 1024
@@ -29,8 +29,8 @@ enum state_t {
     ST_BLOCKED /* Blocked waiting for an event */
 };
 
-/* Maximum TIDs per process (slots 1-5, so 5 threads per process) */
-#define MAX_TIDS_PER_PROCESS 5
+/* Maximum TIDs per process: 10 threads (slots 0-9) */
+#define MAX_TIDS_PER_PROCESS 10
 
 /* Process control block structure */
 struct task_struct {
@@ -46,12 +46,12 @@ struct task_struct {
     int pending_unblocks;                 /* Number of pending unblock operations */
 
     /* Thread support fields */
-    int TID;                              /* Thread identifier: PID*10 + slot (1-5). Idle=10 */
+    int TID;                              /* Thread identifier: PID*10 + slot (0-9). Idle=0 */
     int thread_count;                     /* Number of threads in process */
     struct task_struct *master_thread;    /* Pointer to master thread */
     struct list_head threads;             /* List of threads in this process */
     struct list_head thread_list;         /* Entry in master thread's threads list */
-    int tid_slots[6];                     /* TID slots: index 0 unused, 1-5 valid. 0=free, 1=used */
+    int tid_slots[MAX_TIDS_PER_PROCESS];  /* TID slots: indices 0-9. 0=free, 1=used */
     int *user_stack_ptr;                  /* Pointer to user stack for this thread */
     int user_stack_frames;                /* Number of pages allocated for user stack */
     unsigned int user_stack_region_start; /* First logical page reserved for the stack region */

--- a/project/include/sys.h
+++ b/project/include/sys.h
@@ -166,14 +166,16 @@ int check_fd(int fd, int permissions);
  *
  * This function creates a new thread that executes the specified function
  * with the given parameter. The thread shares the same address space as
- * the parent but has its own user stack.
+ * the parent but has its own user stack. The wrapper function is called
+ * first, which in turn calls the actual thread function and ensures
+ * ThreadExit is called when the function returns.
  *
  * @param function Pointer to the function the thread will execute.
  * @param parameter Parameter to pass to the thread function.
- * @param exit_routine Pointer to the routine to call when the thread function returns.
+ * @param wrapper Pointer to the thread wrapper function that calls function and ThreadExit.
  * @return Thread ID (TID) of the new thread on success, negative error code on failure.
  */
-int sys_create_thread(void (*function)(void *), void *parameter, void (*exit_routine)(void));
+int sys_create_thread(void (*function)(void *), void *parameter, void (*wrapper)(void));
 
 /**
  * @brief Exit the current thread.

--- a/project/include/sys.h
+++ b/project/include/sys.h
@@ -9,6 +9,23 @@
 #ifndef __SYS_H__
 #define __SYS_H__
 
+#include <sched.h>
+
+/* File descriptor permissions */
+#define FD_READ 0
+#define FD_WRITE 1
+
+/* System buffer size for kernel operations */
+#define SYS_BUFFER_SIZE 256
+
+/* Kernel stack offsets for accessing saved context (used in thread/fork setup) */
+#define STACK_USER_EIP (KERNEL_STACK_SIZE - 5)  /* User EIP in hardware context */
+#define STACK_USER_ESP (KERNEL_STACK_SIZE - 2)  /* User ESP in hardware context */
+#define STACK_EAX (KERNEL_STACK_SIZE - 10)      /* EAX in software context */
+#define STACK_EBP (KERNEL_STACK_SIZE - 11)      /* EBP in software context */
+#define STACK_RET_ADDR (KERNEL_STACK_SIZE - 18) /* Return address for switch_context */
+#define STACK_FAKE_EBP (KERNEL_STACK_SIZE - 19) /* Fake EBP for switch_context pop */
+
 /**
  * KERNEL STACK LAYOUT FOR CHILD PROCESS (sys_fork)
  * ================================================
@@ -192,5 +209,12 @@ void sys_exit_thread(void);
  * when a page fault occurs. Returns 0 on success or a negative errno code on failure.
  */
 int grow_user_stack(unsigned int fault_addr);
+
+/**
+ * @brief Gets the thread identifier (TID) of the current thread.
+ *
+ * @return The thread identifier (TID) of the current thread.
+ */
+int sys_gettid(void);
 
 #endif /* __SYS_H__ */

--- a/project/include/utils.h
+++ b/project/include/utils.h
@@ -82,6 +82,16 @@ extern unsigned long get_ticks(void);
 extern void itoa_hex(unsigned int num, char *buffer);
 
 /**
+ * @brief Convert unsigned integer to ASCII string.
+ *
+ * This function converts an unsigned integer to its decimal string representation.
+ * Handles the full range of unsigned int including values > INT_MAX.
+ * @param a Unsigned integer to convert.
+ * @param b Buffer to store the decimal string.
+ */
+extern void utoa(unsigned int a, char *b);
+
+/**
  * @brief Print system splash screen.
  *
  * This function prints the ZeOS startup splash screen with system information.

--- a/project/io.c
+++ b/project/io.c
@@ -111,6 +111,7 @@ void printk_color_fmt(Word color, char *fmt, ...) {
     char buffer[32];
     char *str;
     int num;
+    unsigned int unum;
 
     for (int i = 0; fmt[i] != '\0'; i++) {
         if (fmt[i] != '%') {
@@ -124,9 +125,11 @@ void printk_color_fmt(Word color, char *fmt, ...) {
             num = __builtin_va_arg(args, int);
             if (num < 0) {
                 printc('-', color);
-                num = -num;
+                unum = -(unsigned int)num;
+            } else {
+                unum = (unsigned int)num;
             }
-            itoa(num, buffer);
+            utoa(unum, buffer);
             printk_color(buffer, color);
             break;
         case 'x': // Hexadecimal

--- a/project/io.c
+++ b/project/io.c
@@ -16,11 +16,6 @@
 /** Screen  ***/
 /**************/
 
-/* VGA text mode constants */
-#define NUM_COLUMNS 80            /* Number of columns in text mode (80 chars per row) */
-#define NUM_ROWS 25               /* Number of rows in text mode (25 rows total) */
-#define VIDEO_MEMORY_BASE 0xb8000 /* Base address of VGA text mode video memory */
-
 /* Current cursor column position (0-79) */
 Byte x = 0;
 

--- a/project/libc.c
+++ b/project/libc.c
@@ -13,6 +13,9 @@
 
 int errno;
 
+/* Internal buffer for printf formatting */
+static char printf_buffer[PRINTF_BUFFER_SIZE];
+
 void itoa(int a, char *b) {
     int i, i1;
     char c;
@@ -81,4 +84,77 @@ void perror() {
     write(1, msg, strlen(msg));
 
     return;
+}
+
+void prints(const char *fmt, ...) {
+    __builtin_va_list args;
+    __builtin_va_start(args, fmt);
+
+    char *buf = printf_buffer;
+    int buf_idx = 0;
+    char num_buf[16];
+
+    while (*fmt && buf_idx < PRINTF_BUFFER_SIZE - 1) {
+        if (*fmt == '%' && *(fmt + 1)) {
+            fmt++;
+            switch (*fmt) {
+            case 'd': {
+                int val = __builtin_va_arg(args, int);
+                int is_neg = 0;
+                if (val < 0) {
+                    is_neg = 1;
+                    val = -val;
+                }
+                /* Convert to string */
+                int i = 0;
+                if (val == 0) {
+                    num_buf[i++] = '0';
+                } else {
+                    while (val > 0 && i < 15) {
+                        num_buf[i++] = (val % 10) + '0';
+                        val /= 10;
+                    }
+                }
+                if (is_neg && buf_idx < PRINTF_BUFFER_SIZE - 1) {
+                    buf[buf_idx++] = '-';
+                }
+                /* Reverse and copy */
+                while (i > 0 && buf_idx < PRINTF_BUFFER_SIZE - 1) {
+                    buf[buf_idx++] = num_buf[--i];
+                }
+                break;
+            }
+            case 's': {
+                char *str = __builtin_va_arg(args, char *);
+                while (*str && buf_idx < PRINTF_BUFFER_SIZE - 1) {
+                    buf[buf_idx++] = *str++;
+                }
+                break;
+            }
+            case 'c': {
+                char c = (char)__builtin_va_arg(args, int);
+                buf[buf_idx++] = c;
+                break;
+            }
+            case '%':
+                buf[buf_idx++] = '%';
+                break;
+            default:
+                buf[buf_idx++] = '%';
+                if (buf_idx < PRINTF_BUFFER_SIZE - 1) {
+                    buf[buf_idx++] = *fmt;
+                }
+                break;
+            }
+            fmt++;
+        } else {
+            buf[buf_idx++] = *fmt++;
+        }
+    }
+
+    __builtin_va_end(args);
+
+    if (buf_idx > 0) {
+        write(1, buf, buf_idx);
+    }
 }

--- a/project/libc.c
+++ b/project/libc.c
@@ -101,18 +101,21 @@ void prints(const char *fmt, ...) {
             case 'd': {
                 int val = __builtin_va_arg(args, int);
                 int is_neg = 0;
+                unsigned int uval;
                 if (val < 0) {
                     is_neg = 1;
-                    val = -val;
+                    uval = -(unsigned int)val;
+                } else {
+                    uval = (unsigned int)val;
                 }
                 /* Convert to string */
                 int i = 0;
-                if (val == 0) {
+                if (uval == 0) {
                     num_buf[i++] = '0';
                 } else {
-                    while (val > 0 && i < 15) {
-                        num_buf[i++] = (val % 10) + '0';
-                        val /= 10;
+                    while (uval > 0 && i < 15) {
+                        num_buf[i++] = (uval % 10) + '0';
+                        uval /= 10;
                     }
                 }
                 if (is_neg && buf_idx < PRINTF_BUFFER_SIZE - 1) {

--- a/project/sys.c
+++ b/project/sys.c
@@ -647,10 +647,14 @@ void sys_exit_thread(void) {
     INIT_LIST_HEAD(&new_master->threads);
 
     /* Update all threads to point to new master */
-    list_for_each(pos, &master->threads) {
+    /* Must use list_for_each_safe because we modify the list during iteration */
+    struct list_head *tmp;
+    list_for_each_safe(pos, tmp, &master->threads) {
         struct task_struct *t = list_entry(pos, struct task_struct, thread_list);
         if (t == master) continue;
         t->master_thread = new_master;
+        /* Must remove from old list BEFORE adding to new list */
+        list_del(&t->thread_list);
         list_add_tail(&t->thread_list, &new_master->threads);
     }
 

--- a/project/sys_call_table.S
+++ b/project/sys_call_table.S
@@ -15,8 +15,8 @@ ENTRY (sys_call_table)
     .long sys_fork          # 2 (ok)
     .long sys_ni_syscall    # 3
     .long sys_write			# 4 (ok)
-    .long sys_exit_thread	# 5 ()
-    .long sys_create_thread	# 6 ()
+    .long sys_exit_thread	# 5 (ok)
+    .long sys_create_thread	# 6 (ok)
     .long sys_ni_syscall	# 7
     .long sys_ni_syscall	# 8
     .long sys_ni_syscall	# 9

--- a/project/sys_call_wrappers.S
+++ b/project/sys_call_wrappers.S
@@ -179,6 +179,9 @@ unblock_error:
     ret
 
 
+
+
+
 ENTRY(ThreadCreate)
     pushl %ebp
     movl %esp, %ebp
@@ -187,7 +190,7 @@ ENTRY(ThreadCreate)
     movl $6, %eax
     movl 0x08(%ebp), %ebx  # function pointer
     movl 0x0c(%ebp), %ecx  # parameter
-    leal ThreadExit, %edx  # exit_routine
+    leal thread_entry_wrapper, %edx  # wrapper function address
     
     pushl $tc_return
     pushl %ebp
@@ -251,3 +254,10 @@ gtid_error:
     movl $-1, %eax
     ret
 
+ENTRY(thread_entry_wrapper)
+    movl 4(%esp), %eax      # %eax = function pointer
+    movl 8(%esp), %ecx      # %ecx = parameter
+    pushl %ecx
+    call *%eax
+    addl $4, %esp
+    call ThreadExit         # ALWAYS call ThreadExit when function returns

--- a/project/utils.c
+++ b/project/utils.c
@@ -136,6 +136,31 @@ void itoa_hex(unsigned int num, char *buffer) {
     buffer[10] = '\0';
 }
 
+void utoa(unsigned int a, char *b) {
+    int i, i1;
+    char c;
+
+    if (a == 0) {
+        b[0] = '0';
+        b[1] = 0;
+        return;
+    }
+
+    i = 0;
+    while (a > 0) {
+        b[i] = (a % 10) + '0';
+        a = a / 10;
+        i++;
+    }
+
+    for (i1 = 0; i1 < i / 2; i1++) {
+        c = b[i1];
+        b[i1] = b[i - i1 - 1];
+        b[i - i1 - 1] = c;
+    }
+    b[i] = 0;
+}
+
 void wait_ticks(int ticks_to_wait) {
     unsigned long start_ticks = get_ticks();
     while (get_ticks() - start_ticks < (unsigned long)ticks_to_wait) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce user-level threads with ThreadCreate/ThreadExit, per-thread stacks (on-demand growth), new TID scheme (10 slots, idle=0), fork copying only the calling thread, gettid, and extensive tests/utilities.
> 
> - **Kernel/ABI**:
>   - **New syscalls**: `sys_create_thread(function, parameter, wrapper)`, `sys_exit_thread`, `sys_gettid`; wired in `sys_call_table.S` and wrappers (`ThreadCreate`, `ThreadExit`, `gettid`).
>   - **Thread entry wrapper**: `thread_entry_wrapper` ensures `ThreadExit` is called after user function returns.
>   - **TID scheme**: 10 TIDs per process (`PID*10 + 0..9`), idle `TID=0`, init uses slot 0.
> - **Scheduler/Task Management**:
>   - `NR_TASKS` → 25; add thread fields to `task_struct` and TID slot management (`init_tid_slots`, `allocate_tid`, `free_tid`).
>   - Initialize init thread with dedicated user stack; update context switch helpers/offsets.
> - **Memory Management/Stacks**:
>   - Per-thread user stacks: reserved region, 1 page initially, on-demand growth via `grow_user_stack` and `TEMP_STACK_MAPPING_PAGE`.
>   - `fork` copies only the calling thread; duplicates its user stack via temp mapping; child starts single-threaded.
> - **Userland/Lib**:
>   - Add `prints()` (mini-printf) and `utoa`; improve `printk_color_fmt` integer handling; expose VGA constants in `io.h`.
>   - Public API in `libc.h` for threads (`ThreadCreate`, `ThreadExit`, `thread_entry_wrapper`) and docs/comments.
> - **Tests**:
>   - Comprehensive thread tests (`project_test.c/h`): max threads (10), limit enforcement, TID reuse, last-thread exit, master reassignment, fork-single-thread, wrapper auto-exit; enable `IDLE_SWITCH_TEST`.
> - **Docs**:
>   - Add `docs/project_milestones/M1_thread_support.txt` detailing design and changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 997e95bbe96dfadb691ab0a1f888c01ccb751d00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->